### PR TITLE
fix: close admin overlays on route change

### DIFF
--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -57,6 +57,12 @@ const AdminSidebar: React.FC = () => {
   const [siteInfo, setSiteInfo] = useState<{ siteName: string; logoUrl: string } | null>(null);
   const [expandedMenus, setExpandedMenus] = useState<Set<string>>(new Set());
 
+  // ปิดเมนูมือถือและป๊อปอัปแจ้งเตือนเมื่อมีการเปลี่ยนเส้นทาง
+  useEffect(() => {
+    setShowNotifications(false);
+    setIsMobileMenuOpen(false);
+  }, [pathname]);
+
   // ฟังก์ชันเล่นเสียงแจ้งเตือน
   const playNotificationSound = () => {
     if (!hasUserInteracted) return;


### PR DESCRIPTION
## Summary
- close mobile menu and notification popover when navigating in admin area

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a40d88fff88331b24d50f7931f88be