### PR TITLE
fix: forward Messenger webhook to worker to avoid duplicate replies

### DIFF
--- a/src/app/api/messenger/webhook/route.ts
+++ b/src/app/api/messenger/webhook/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { handleEvent } from '@/bot/flows/entry';
 import { verifyRequestSignature } from '@/utils/messenger';
 
 // Edge Webhook: ตอบ Facebook เร็วที่สุด แล้ว forward ไปยัง worker (Node)
@@ -34,19 +33,30 @@ export async function POST(request: NextRequest) {
     return new NextResponse('invalid_signature', { status: 400 });
   }
 
-  const body = JSON.parse(rawBody);
+  let body: any;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ status: 'invalid_body' }, { status: 400 });
+  }
+
   console.log('[Webhook] Received body', JSON.stringify(body));
 
   if (body.object !== 'page') {
     return NextResponse.json({ status: 'ignored' });
   }
 
-  const events = body.entry?.flatMap((e: any) => e.messaging) || [];
-  console.log('[Webhook] Total events', events.length);
+  // Forward events to worker asynchronously เพื่อไม่ให้คำขอค้างนาน
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.winrichdynamic.com';
+  fetch(`${baseUrl}/api/worker/messenger`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-hub-signature-256': signature || '',
+    },
+    body: rawBody,
+  }).catch((err) => console.error('[Webhook] forward error', err));
 
-  await Promise.all(
-    events.map((ev: any) => handleEvent(ev).catch((err) => console.error('Handle event error', err)))
-  );
-
-  return NextResponse.json({ status: 'processed' });
-} 
+  // ตอบกลับ Facebook ทันที
+  return NextResponse.json({ status: 'accepted' });
+}


### PR DESCRIPTION
## Summary
- forward Messenger webhook events to a worker endpoint and reply immediately to Facebook

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a42b62c5888331b983c36bb7e4247c