### PR TITLE
fix: keep admin sidebar accessible across pages

### DIFF
--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -497,7 +497,7 @@ const AdminSidebar: React.FC = () => {
         </div>
         
         {/* Desktop Sidebar */}
-        <aside className="w-56 h-screen bg-white border-r border-gray-200 hidden md:block sticky top-0">
+        <aside className="w-56 h-screen bg-white border-r border-gray-200 hidden md:block sticky top-0 z-50">
           <div className="flex items-center justify-center h-full">
             <div className="text-center">
               <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-blue-500 mx-auto"></div>
@@ -711,7 +711,8 @@ const AdminSidebar: React.FC = () => {
       </AnimatePresence>
 
       {/* Desktop Sidebar */}
-      <aside className="w-56 h-screen bg-white border-r border-gray-200 hidden md:block sticky top-0">
+      {/* Ensure sidebar stays above page content on all routes */}
+      <aside className="w-56 h-screen bg-white border-r border-gray-200 hidden md:block sticky top-0 z-50">
       <div className="p-6 border-b border-gray-200">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- ensure desktop admin sidebar sits above content so navigation always works

## Testing
- `npm run lint` *(fails: 'err' is defined but never used, plus many other type warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a42f0f2ff88331b9a66dc5b9bc2108