### PR TITLE
fix: keep admin sidebar accessible across admin pages

### DIFF
--- a/src/app/(shop)/admin/layout.tsx
+++ b/src/app/(shop)/admin/layout.tsx
@@ -8,10 +8,10 @@ interface Props {
 
 const AdminLayout: React.FC<Props> = ({ children }) => {
   return (
-    <div className="min-h-screen flex bg-gray-50">
+    <div className="min-h-screen bg-gray-50">
       <Toaster position="top-right" />
       <AdminSidebar />
-      <main className="flex-1 pt-16 md:pt-8 p-4 md:p-8 overflow-x-auto">{children}</main>
+      <main className="pt-16 md:pt-8 p-4 md:p-8 md:ml-56 overflow-x-auto">{children}</main>
     </div>
   );
 };

--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -497,7 +497,7 @@ const AdminSidebar: React.FC = () => {
         </div>
         
         {/* Desktop Sidebar */}
-        <aside className="w-56 h-screen bg-white border-r border-gray-200 hidden md:block sticky top-0 z-50">
+        <aside className="w-56 h-screen bg-white border-r border-gray-200 hidden md:block sticky top-0 z-[100]">
           <div className="flex items-center justify-center h-full">
             <div className="text-center">
               <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-blue-500 mx-auto"></div>
@@ -554,7 +554,7 @@ const AdminSidebar: React.FC = () => {
             animate={{ x: 0 }}
             exit={{ x: '-100%' }}
             transition={{ type: 'tween', duration: 0.3 }}
-            className="md:hidden fixed left-0 top-0 w-64 h-screen bg-white border-r border-gray-200 z-50 overflow-y-auto"
+            className="md:hidden fixed left-0 top-0 w-64 h-screen bg-white border-r border-gray-200 z-[100] overflow-y-auto"
           >
             <div className="p-6 border-b border-gray-200">
               <div className="flex items-center justify-between">
@@ -711,8 +711,8 @@ const AdminSidebar: React.FC = () => {
       </AnimatePresence>
 
       {/* Desktop Sidebar */}
-      {/* Ensure sidebar stays above page content on all routes */}
-      <aside className="w-56 h-screen bg-white border-r border-gray-200 hidden md:block sticky top-0 z-50">
+      {/* Use fixed positioning so content on other pages can't block the sidebar */}
+      <aside className="w-56 h-screen bg-white border-r border-gray-200 hidden md:block fixed top-0 left-0 z-[100]">
       <div className="p-6 border-b border-gray-200">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- raise admin sidebar z-index so page content can't cover navigation links

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4336d766c8331860fb15ce63f9df3