### PR TITLE
Fix admin sidebar z-index to enable menu navigation

### DIFF
--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -712,7 +712,7 @@ const AdminSidebar: React.FC = () => {
 
       {/* Desktop Sidebar */}
       {/* Use fixed positioning so content on other pages can't block the sidebar */}
-      <aside className="w-56 h-screen bg-white border-r border-gray-200 hidden md:block fixed top-0 left-0 z-100">
+      <aside className="w-56 h-screen bg-white border-r border-gray-200 hidden md:block fixed top-0 left-0 z-[100]">
       <div className="p-6 border-b border-gray-200">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- ensure admin sidebar uses z-index 100 via Tailwind bracket syntax so it sits above other content

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: linting errors across project)*

------
https://chatgpt.com/codex/tasks/task_e_68a43d422e248331a714ccc752e02219