### PR TITLE
Fix admin sidebar overlay

### DIFF
--- a/src/app/(shop)/admin/layout.tsx
+++ b/src/app/(shop)/admin/layout.tsx
@@ -8,10 +8,10 @@ interface Props {
 
 const AdminLayout: React.FC<Props> = ({ children }) => {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 overflow-x-hidden md:pl-56">
       <Toaster position="top-right" />
       <AdminSidebar />
-      <main className="pt-16 md:pt-8 p-4 md:p-8 md:ml-56 overflow-x-auto">{children}</main>
+      <main className="pt-16 md:pt-8 p-4 md:p-8 overflow-x-auto">{children}</main>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- reserve space for the fixed admin sidebar using `md:pl-56` so main content no longer covers it

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors in existing files)*
- `npm run build` *(fails: could not fetch Inter font)*

------
https://chatgpt.com/codex/tasks/task_e_68a4459e38d483318e0716781e805f92