### PR TITLE
fix(admin-sidebar): raise z-index for sidebar asides

### DIFF
--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -497,7 +497,7 @@ const AdminSidebar: React.FC = () => {
         </div>
         
         {/* Desktop Sidebar */}
-        <aside className="w-56 h-screen bg-white border-r border-gray-200 hidden md:block sticky top-0 z-[100]">
+        <aside className="w-56 h-screen bg-white border-r border-gray-200 hidden md:block sticky top-0 z-[9999]">
           <div className="flex items-center justify-center h-full">
             <div className="text-center">
               <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-blue-500 mx-auto"></div>
@@ -554,7 +554,7 @@ const AdminSidebar: React.FC = () => {
             animate={{ x: 0 }}
             exit={{ x: '-100%' }}
             transition={{ type: 'tween', duration: 0.3 }}
-            className="md:hidden fixed left-0 top-0 w-64 h-screen bg-white border-r border-gray-200 z-[100] overflow-y-auto"
+            className="md:hidden fixed left-0 top-0 w-64 h-screen bg-white border-r border-gray-200 z-[9999] overflow-y-auto"
           >
             <div className="p-6 border-b border-gray-200">
               <div className="flex items-center justify-between">
@@ -712,7 +712,7 @@ const AdminSidebar: React.FC = () => {
 
       {/* Desktop Sidebar */}
       {/* Use fixed positioning so content on other pages can't block the sidebar */}
-      <aside className="w-56 h-screen bg-white border-r border-gray-200 hidden md:block fixed top-0 left-0 z-[100]">
+      <aside className="w-56 h-screen bg-white border-r border-gray-200 hidden md:block fixed top-0 left-0 z-[9999]">
       <div className="p-6 border-b border-gray-200">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- raise admin sidebar z-index to 9999 for loading, mobile, and desktop asides to avoid overlap

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: numerous ESLint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a354d1308331a79bd9ce96a467e2