### PR TITLE
Add button type to submenu toggles

### DIFF
--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -597,6 +597,7 @@ const AdminSidebar: React.FC = () => {
                     {item.submenu ? (
                       <div>
                         <button
+                          type="button"
                           onClick={() => toggleSubmenu(item.label)}
                           className={`flex items-center justify-between w-full px-3 py-3 text-left rounded-lg transition-colors ${
                             pathname === item.href || pathname.startsWith(item.href + '/')
@@ -888,6 +889,7 @@ const AdminSidebar: React.FC = () => {
               {item.submenu ? (
                 <div>
                   <button
+                    type="button"
                     onClick={() => {
                       console.log('Menu button clicked:', item.label, item.href);
                       toggleSubmenu(item.label);


### PR DESCRIPTION
## Summary
- avoid unwanted form submissions by setting type="button" on mobile submenu toggles
- ensure desktop submenu buttons are non-submit buttons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a34097d88331bbf006d8b10c7db0