### PR TITLE
refactor: rely on admin layout toaster

### DIFF
--- a/src/app/(shop)/admin/admins/page.tsx
+++ b/src/app/(shop)/admin/admins/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { toast, Toaster } from 'react-hot-toast';
+import { toast } from 'react-hot-toast';
 
 interface AdminPhone {
   _id: string;
@@ -53,7 +53,6 @@ const AdminsPage = () => {
 
   return (
     <div className="max-w-lg mx-auto">
-      <Toaster />
       <h1 className="text-2xl font-bold mb-4">จัดการผู้ดูแล</h1>
 
       <div className="flex mb-6 gap-2">

--- a/src/app/(shop)/admin/categories/page.tsx
+++ b/src/app/(shop)/admin/categories/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, FormEvent, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { toast, Toaster } from 'react-hot-toast';
+import { toast } from 'react-hot-toast';
 import { PermissionGate } from '@/components/PermissionGate';
 import { usePermissions } from '@/hooks/usePermissions';
 import { PERMISSIONS } from '@/constants/permissions';
@@ -196,7 +196,6 @@ const AdminCategoriesPage = () => {
   return (
     <PermissionGate permission={PERMISSIONS.PRODUCTS_VIEW}>
       <div className="min-h-screen bg-gray-50">
-        <Toaster position="top-right" />
       
         <div className="container mx-auto px-4 py-8">
           {/* Header */}

--- a/src/app/(shop)/admin/orders/claims/page.tsx
+++ b/src/app/(shop)/admin/orders/claims/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Toaster, toast } from 'react-hot-toast';
+import { toast } from 'react-hot-toast';
 
 interface OrderItem {
   productId: string;
@@ -163,7 +163,6 @@ const AdminClaimsPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Toaster position="top-right" />
       
       <div className="container mx-auto px-4 py-8">
         {/* Header */}

--- a/src/app/(shop)/admin/orders/delivered/page.tsx
+++ b/src/app/(shop)/admin/orders/delivered/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { motion } from 'framer-motion';
-import toast, { Toaster } from 'react-hot-toast';
+import toast from 'react-hot-toast';
 
 interface OrderItem {
   productId: string;
@@ -103,7 +103,6 @@ const DeliveredOrdersPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Toaster position="top-right" />
       
       <div className="container mx-auto px-4 py-8">
         <div className="mb-8">

--- a/src/app/(shop)/admin/orders/failed/page.tsx
+++ b/src/app/(shop)/admin/orders/failed/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { motion } from 'framer-motion';
-import toast, { Toaster } from 'react-hot-toast';
+import toast from 'react-hot-toast';
 
 interface OrderItem {
   productId: string;
@@ -141,7 +141,6 @@ const ShippingManagementPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Toaster position="top-right" />
       
       <div className="container mx-auto px-4 py-8">
         <div className="mb-8">

--- a/src/app/(shop)/admin/orders/page.tsx
+++ b/src/app/(shop)/admin/orders/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Toaster, toast } from 'react-hot-toast';
+import { toast } from 'react-hot-toast';
 import PackingImageGallery from '@/components/PackingImageGallery';
 import { PermissionGate } from '@/components/PermissionGate';
 import { usePermissions } from '@/hooks/usePermissions';
@@ -718,7 +718,6 @@ const AdminOrdersPage = () => {
   return (
     <PermissionGate permission={PERMISSIONS.ORDERS_VIEW}>
       <div className="min-h-screen bg-gray-50">
-        <Toaster position="top-right" />
       
       <div className="container mx-auto px-4 py-8">
         {/* Header */}

--- a/src/app/(shop)/admin/orders/processing/page.tsx
+++ b/src/app/(shop)/admin/orders/processing/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { motion } from 'framer-motion';
-import toast, { Toaster } from 'react-hot-toast';
+import toast from 'react-hot-toast';
 import Image from 'next/image';
 
 interface OrderItem {
@@ -150,7 +150,6 @@ const ProcessingOrdersPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Toaster position="top-right" />
       
       <div className="container mx-auto px-4 py-8">
         <div className="mb-8">

--- a/src/app/(shop)/admin/orders/tax-invoices/page.tsx
+++ b/src/app/(shop)/admin/orders/tax-invoices/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { motion } from 'framer-motion';
-import toast, { Toaster } from 'react-hot-toast';
+import toast from 'react-hot-toast';
 
 interface OrderItem {
   productId: string;
@@ -137,7 +137,6 @@ const TaxInvoicesPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Toaster position="top-right" />
       
       <div className="container mx-auto px-4 py-8">
         <div className="mb-8">

--- a/src/app/(shop)/admin/products/page.tsx
+++ b/src/app/(shop)/admin/products/page.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect, FormEvent, useCallback } from 'react';
 import Image from 'next/image';
 import { IProduct } from '@/models/Product';
 import { motion, AnimatePresence } from 'framer-motion';
-import { toast, Toaster } from 'react-hot-toast';
+import { toast } from 'react-hot-toast';
 import { PermissionGate } from '@/components/PermissionGate';
 import { usePermissions } from '@/hooks/usePermissions';
 import { PERMISSIONS } from '@/constants/permissions';
@@ -977,9 +977,7 @@ const AdminProductsPage = () => {
   return (
     <PermissionGate permission={PERMISSIONS.PRODUCTS_VIEW}>
       <div className="min-h-screen bg-gray-50">
-        <Toaster position="top-right" />
-      
-      <div className="container mx-auto px-4 py-8">
+        <div className="container mx-auto px-4 py-8">
         {/* Header */}
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-3">
           <div>

--- a/src/app/(shop)/admin/settings/page.tsx
+++ b/src/app/(shop)/admin/settings/page.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { usePermissions } from '@/hooks/usePermissions';
 import { PERMISSIONS } from '@/constants/permissions';
 import Image from 'next/image';
-import toast, { Toaster } from 'react-hot-toast';
+import toast from 'react-hot-toast';
 
 export default function AdminSettingsPage() {
   const { isAdmin, hasPermission, loading } = usePermissions();
@@ -66,7 +66,6 @@ export default function AdminSettingsPage() {
 
   return (
     <div className="max-w-3xl mx-auto p-6">
-      <Toaster position="top-right" />
       <h1 className="text-2xl font-semibold mb-6">ตั้งค่าทั่วไป</h1>
 
       <div className="bg-white p-6 rounded-lg border border-gray-200 space-y-6">


### PR DESCRIPTION
## Summary
- remove redundant Toaster components from admin pages
- keep a single Toaster in the admin layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a3539a388331b1ae9c6c561940e0