### PR TITLE
Refactor Cloudinary buffer upload stream handling

### DIFF
--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -51,10 +51,13 @@ export async function uploadImage(
       result = await cloudinary.uploader.upload(file, uploadOptions);
     } else {
       // Upload from buffer
-      result = await cloudinary.uploader.upload_stream(uploadOptions, (error, result) => {
-        if (error) throw error;
-        return result;
-      }).end(file);
+      result = await new Promise((resolve, reject) => {
+        const stream = cloudinary.uploader.upload_stream(uploadOptions, (error, res) => {
+          if (error) return reject(error);
+          resolve(res);
+        });
+        stream.end(file);
+      });
     }
 
     return {


### PR DESCRIPTION
## Summary
- handle buffer uploads by wrapping `cloudinary.uploader.upload_stream` in a Promise

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Multiple ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4af7455008331863e54a3f08fe331