### PR TITLE
feat: centralize site info with shared context

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,56 +1,51 @@
-'use client';
-
 import { Inter } from 'next/font/google';
 import './globals.css';
 import './mobile-keyboard-fix.css';
 import { AuthProvider } from '@/contexts/AuthContext';
-import React, { useEffect, useState } from 'react';
-import { startAutoCartClearScheduler } from '@/utils/scheduler';
-import { startPerformanceMonitoring } from '@/utils/performance';
-import { initMobileKeyboardFix } from '@/utils/mobile-keyboard-fix';
-import { Metadata } from 'next';
+import ClientSideEffects from '@/components/ClientSideEffects';
+import { SiteInfoProvider, SiteInfo } from '@/contexts/SiteInfoContext';
 
-const inter = Inter({ 
+const inter = Inter({
   subsets: ['latin'],
   display: 'swap',
   preload: false, // Changed from true to false to prevent preload warnings
   fallback: ['system-ui', 'arial']
 });
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const [siteInfo, setSiteInfo] = useState<{ siteName: string; logoUrl: string; description?: string } | null>(null);
-  
-  useEffect(() => {
-    // เริ่มต้น scheduler สำหรับล้างตะกร้าอัตโนมัติ
-    startAutoCartClearScheduler();
-    
-    // เริ่มต้น performance monitoring
-    startPerformanceMonitoring();
-    
-    // เริ่มต้นการแก้ไขปัญหาการไม่ขึ้นแป้นพิมพ์บนมือถือแอนดรอยด์
-    initMobileKeyboardFix();
-  }, []);
+  let siteInfo: SiteInfo = {
+    siteName: 'WINRICH DYNAMIC',
+    logoUrl: '/favicon.ico',
+    description:
+      'ระบบจัดการร้านค้าออนไลน์ที่ครบครันสำหรับธุรกิจขนาดกลางและขนาดใหญ่ พัฒนาด้วย Next.js, TypeScript และ MongoDB'
+  };
 
-  useEffect(() => {
-    fetch('/api/admin/settings/logo', { cache: 'no-store' })
-      .then(r => r.json())
-      .then(data => {
-        if (data?.success) setSiteInfo({ 
-          siteName: data.data.siteName, 
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_BASE_URL || 'https://www.winrichdynamic.com'}/api/admin/settings/logo`,
+      {
+        next: { revalidate: 3600 }
+      }
+    );
+    if (response.ok) {
+      const data = await response.json();
+      if (data?.success) {
+        siteInfo = {
+          siteName: data.data.siteName,
           logoUrl: data.data.logoUrl,
-          description: data.data.description || 'ระบบจัดการร้านค้าออนไลน์ที่ครบครันสำหรับธุรกิจขนาดกลางและขนาดใหญ่'
-        });
-      })
-      .catch(() => {});
-  }, []);
+          description: data.data.description || siteInfo.description
+        };
+      }
+    }
+  } catch (error) {
+    // ignore errors and use default site info
+  }
 
-  const siteName = siteInfo?.siteName || 'WINRICH DYNAMIC';
-  const description = siteInfo?.description || 'ระบบจัดการร้านค้าออนไลน์ที่ครบครันสำหรับธุรกิจขนาดกลางและขนาดใหญ่ พัฒนาด้วย Next.js, TypeScript และ MongoDB';
-  const logoUrl = siteInfo?.logoUrl || '/favicon.ico';
+  const { siteName, description, logoUrl } = siteInfo;
 
   return (
     <html lang="th" className="scroll-smooth">
@@ -59,14 +54,14 @@ export default function RootLayout({
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         <meta name="theme-color" content="#223f81" />
         <meta name="color-scheme" content="light dark" />
-        
+
         {/* SEO Meta Tags */}
         <title>{siteName}</title>
         <meta name="description" content={description} />
         <meta name="keywords" content="ร้านค้าออนไลน์, ระบบจัดการ, e-commerce, Next.js, TypeScript, MongoDB" />
         <meta name="author" content="WinRich Team" />
         <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
-        
+
         {/* Open Graph / Facebook */}
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://winrichdynamic.com" />
@@ -75,101 +70,104 @@ export default function RootLayout({
         <meta property="og:image" content={logoUrl} />
         <meta property="og:site_name" content={siteName} />
         <meta property="og:locale" content="th_TH" />
-        
+
         {/* Twitter */}
         <meta property="twitter:card" content="summary_large_image" />
         <meta property="twitter:url" content="https://winrichdynamic.com" />
         <meta property="twitter:title" content={siteName} />
         <meta property="twitter:description" content={description} />
         <meta property="twitter:image" content={logoUrl} />
-        
+
         {/* Additional Meta Tags */}
         <meta name="format-detection" content="telephone=no" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="apple-mobile-web-app-title" content={siteName} />
-        
+
         {/* Icons - Fixed paths */}
         <link rel="icon" href="/favicon.ico" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="manifest" href="/site.webmanifest" />
-        
+
         {/* Optimized Resource Loading - Removed problematic preloads */}
         <link rel="dns-prefetch" href="//res.cloudinary.com" />
         <link rel="dns-prefetch" href="//www.winrichdynamic.com" />
         <link rel="preconnect" href="https://res.cloudinary.com" />
-        
+
         {/* Structured Data */}
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: JSON.stringify({
-              "@context": "https://schema.org",
-              "@type": "Organization",
-              "name": siteName,
-              "url": "https://winrichdynamic.com",
-              "logo": logoUrl,
-              "description": description,
-              "contactPoint": {
-                "@type": "ContactPoint",
-                "contactType": "customer service",
-                "availableLanguage": "Thai"
+              '@context': 'https://schema.org',
+              '@type': 'Organization',
+              name: siteName,
+              url: 'https://winrichdynamic.com',
+              logo: logoUrl,
+              description,
+              contactPoint: {
+                '@type': 'ContactPoint',
+                contactType: 'customer service',
+                availableLanguage: 'Thai'
               },
-              "sameAs": [
-                "https://www.facebook.com/winrichdynamic",
-                "https://www.instagram.com/winrichdynamic"
+              sameAs: [
+                'https://www.facebook.com/winrichdynamic',
+                'https://www.instagram.com/winrichdynamic'
               ]
             })
           }}
         />
       </head>
       <body className={`${inter.className} antialiased`}>
-        <AuthProvider>
-          <main className="min-h-screen bg-gray-100">{children}</main>
-          <footer className="bg-white border-t border-gray-200">
-            <div className="container mx-auto px-4 py-8">
-              <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
-                <div>
-                  <h3 className="text-lg font-semibold text-gray-900 mb-4">{siteName}</h3>
-                  <p className="text-gray-600 text-sm">{description}</p>
-                </div>
-                <div>
-                  <h4 className="text-md font-semibold text-gray-900 mb-4">บริการ</h4>
-                  <ul className="space-y-2 text-sm text-gray-600">
-                    <li><a href="/shop" className="hover:text-blue-600">ร้านค้า</a></li>
-                    <li><a href="/articles" className="hover:text-blue-600">บทความ</a></li>
-                    <li><a href="/contact" className="hover:text-blue-600">ติดต่อ</a></li>
-                  </ul>
-                </div>
-                <div>
-                  <h4 className="text-md font-semibold text-gray-900 mb-4">สนับสนุน</h4>
-                  <ul className="space-y-2 text-sm text-gray-600">
-                    <li><a href="/customer-service" className="hover:text-blue-600">บริการลูกค้า</a></li>
-                    <li><a href="/customer-service/faq" className="hover:text-blue-600">คำถามที่พบบ่อย</a></li>
-                    <li><a href="/privacy-policy" className="hover:text-blue-600">นโยบายความเป็นส่วนตัว</a></li>
-                  </ul>
-                </div>
-                <div>
-                  <h4 className="text-md font-semibold text-gray-900 mb-4">ติดต่อ</h4>
-                  <div className="text-sm text-gray-600">
-                    <p>📧 info@winrichdynamic.com</p>
-                    <p>📱 02-XXX-XXXX</p>
-                    <p>📍 กรุงเทพมหานคร, ประเทศไทย</p>
+        <SiteInfoProvider siteInfo={siteInfo}>
+          <AuthProvider>
+            <ClientSideEffects />
+            <main className="min-h-screen bg-gray-100">{children}</main>
+            <footer className="bg-white border-t border-gray-200">
+              <div className="container mx-auto px-4 py-8">
+                <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
+                  <div>
+                    <h3 className="text-lg font-semibold text-gray-900 mb-4">{siteName}</h3>
+                    <p className="text-gray-600 text-sm">{description}</p>
+                  </div>
+                  <div>
+                    <h4 className="text-md font-semibold text-gray-900 mb-4">บริการ</h4>
+                    <ul className="space-y-2 text-sm text-gray-600">
+                      <li><a href="/shop" className="hover:text-blue-600">ร้านค้า</a></li>
+                      <li><a href="/articles" className="hover:text-blue-600">บทความ</a></li>
+                      <li><a href="/contact" className="hover:text-blue-600">ติดต่อ</a></li>
+                    </ul>
+                  </div>
+                  <div>
+                    <h4 className="text-md font-semibold text-gray-900 mb-4">สนับสนุน</h4>
+                    <ul className="space-y-2 text-sm text-gray-600">
+                      <li><a href="/customer-service" className="hover:text-blue-600">บริการลูกค้า</a></li>
+                      <li><a href="/customer-service/faq" className="hover:text-blue-600">คำถามที่พบบ่อย</a></li>
+                      <li><a href="/privacy-policy" className="hover:text-blue-600">นโยบายความเป็นส่วนตัว</a></li>
+                    </ul>
+                  </div>
+                  <div>
+                    <h4 className="text-md font-semibold text-gray-900 mb-4">ติดต่อ</h4>
+                    <div className="text-sm text-gray-600">
+                      <p>📧 info@winrichdynamic.com</p>
+                      <p>📱 02-XXX-XXXX</p>
+                      <p>📍 กรุงเทพมหานคร, ประเทศไทย</p>
+                    </div>
                   </div>
                 </div>
+                <div className="border-t border-gray-200 mt-8 pt-8 text-center">
+                  <p className="text-sm text-gray-500">
+                    &copy; {new Date().getFullYear()} {siteName} - สงวนลิขสิทธิ์ |
+                    พัฒนาด้วย ❤️ โดย WinRich Team
+                  </p>
+                </div>
               </div>
-              <div className="border-t border-gray-200 mt-8 pt-8 text-center">
-                <p className="text-sm text-gray-500">
-                  &copy; {new Date().getFullYear()} {siteName} - สงวนลิขสิทธิ์ | 
-                  พัฒนาด้วย ❤️ โดย WinRich Team
-                </p>
-              </div>
-            </div>
-          </footer>
-        </AuthProvider>
+            </footer>
+          </AuthProvider>
+        </SiteInfoProvider>
       </body>
     </html>
   );

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useSiteInfo } from '@/contexts/SiteInfoContext';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -20,6 +21,7 @@ export default function AppHeader({ showSearch = true, onSearchToggle }: AppHead
   const router = useRouter();
   const { isLoggedIn, user, logout } = useAuth();
   const { totalUnread } = useNotificationCounts();
+  const { siteName, logoUrl } = useSiteInfo();
 
   const handleSearchToggle = () => {
     const newState = !isSearchOpen;
@@ -59,18 +61,6 @@ export default function AppHeader({ showSearch = true, onSearchToggle }: AppHead
     { href: '/articles', label: 'บทความ', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" /></svg>, show: true },
   ].filter(item => item.show);
 
-  const [siteInfo, setSiteInfo] = useState<{ siteName: string; logoUrl: string } | null>(null);
-
-  React.useEffect(() => {
-    // โหลดข้อมูลโลโก้/ชื่อเว็บแบบไดนามิก
-    fetch('/api/admin/settings/logo', { cache: 'no-store' })
-      .then(r => r.json())
-      .then(data => {
-        if (data?.success) setSiteInfo({ siteName: data.data.siteName, logoUrl: data.data.logoUrl });
-      })
-      .catch(() => {});
-  }, []);
-
   return (
     <>
       {/* Top App Bar */}
@@ -78,14 +68,14 @@ export default function AppHeader({ showSearch = true, onSearchToggle }: AppHead
         <div className="flex items-center justify-between px-4 py-3">
           {/* Logo and Company Name */}
           <Link href="/shop" aria-label="ไปหน้าร้าน" className="flex items-center space-x-3">
-            {siteInfo?.logoUrl ? (
+            {logoUrl ? (
               <div className="relative w-8 h-8">
-                <Image src={siteInfo.logoUrl} alt="Site Logo" fill sizes="32px" className="object-contain" />
+                <Image src={logoUrl} alt="Site Logo" fill sizes="32px" className="object-contain" />
               </div>
             ) : null}
             <div className="flex flex-col">
-              <div className="text-lg font-bold text-slate-800 leading-tight">{(siteInfo?.siteName || 'WINRICH DYNAMIC').split(' ')[0]}</div>
-              <div className="text-sm font-medium text-slate-600 leading-tight text-center">{(siteInfo?.siteName || 'WINRICH DYNAMIC').split(' ').slice(1).join(' ')}</div>
+              <div className="text-lg font-bold text-slate-800 leading-tight">{siteName.split(' ')[0]}</div>
+              <div className="text-sm font-medium text-slate-600 leading-tight text-center">{siteName.split(' ').slice(1).join(' ')}</div>
             </div>
           </Link>
 
@@ -279,9 +269,9 @@ export default function AppHeader({ showSearch = true, onSearchToggle }: AppHead
                <div className="mt-6 pt-6 border-t border-gray-200">
                  <div className="px-4 py-2 text-center">
                    <div className="flex items-center justify-center space-x-2 mb-2">
-                      {siteInfo?.logoUrl ? (
+                      {logoUrl ? (
                         <div className="relative w-6 h-6">
-                          <Image src={siteInfo.logoUrl} alt="Site Logo" fill sizes="24px" className="object-contain" />
+                          <Image src={logoUrl} alt="Site Logo" fill sizes="24px" className="object-contain" />
                         </div>
                       ) : (
                         <div className="w-6 h-6 relative">
@@ -293,7 +283,7 @@ export default function AppHeader({ showSearch = true, onSearchToggle }: AppHead
                           </div>
                         </div>
                       )}
-                      <div className="text-sm font-bold text-slate-800">{siteInfo?.siteName || 'WINRICH DYNAMIC'}</div>
+                      <div className="text-sm font-bold text-slate-800">{siteName}</div>
                    </div>
                    <p className="text-xs text-gray-500">เวอร์ชัน 1.0.0</p>
                  </div>

--- a/src/components/ClientSideEffects.tsx
+++ b/src/components/ClientSideEffects.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect } from 'react';
+import { startAutoCartClearScheduler } from '@/utils/scheduler';
+import { startPerformanceMonitoring } from '@/utils/performance';
+import { initMobileKeyboardFix } from '@/utils/mobile-keyboard-fix';
+
+export default function ClientSideEffects() {
+  useEffect(() => {
+    startAutoCartClearScheduler();
+    startPerformanceMonitoring();
+    initMobileKeyboardFix();
+  }, []);
+
+  return null;
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
 import React, { useState, useEffect } from "react";
+import { useSiteInfo } from '@/contexts/SiteInfoContext';
 import Image from "next/image";
 
 const menu = [
@@ -47,7 +48,7 @@ export default function Sidebar() {
   const [hovered, setHovered] = useState<string | null>(null);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
-  const [siteInfo, setSiteInfo] = useState<{ siteName: string; logoUrl: string } | null>(null);
+  const { siteName, logoUrl } = useSiteInfo();
 
   // ตรวจจับขนาดหน้าจอเพื่อกำหนด Mobile mode
   useEffect(() => {
@@ -62,15 +63,6 @@ export default function Sidebar() {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  // โหลดข้อมูลโลโก้/ชื่อเว็บจากแอดมิน เหมือนส่วนหัว
-  useEffect(() => {
-    fetch('/api/admin/settings/logo', { cache: 'no-store' })
-      .then(r => r.json())
-      .then(data => {
-        if (data?.success) setSiteInfo({ siteName: data.data.siteName, logoUrl: data.data.logoUrl });
-      })
-      .catch(() => {});
-  }, []);
 
   // ไม่จำเป็นต้องใช้ getSubMenuOffset อีกต่อไป เพราะจะใช้ relative positioning
   
@@ -111,13 +103,13 @@ export default function Sidebar() {
 
         <div className="mb-10">
           <Link href="/" onClick={() => isMobile && setIsMobileMenuOpen(false)} className="flex flex-col items-center gap-2">
-            {siteInfo?.logoUrl ? (
-              <Image src={siteInfo.logoUrl} alt={`${siteInfo.siteName} Logo`} width={isMobile ? 80 : 120} height={isMobile ? 80 : 120} priority />
+            {logoUrl ? (
+              <Image src={logoUrl} alt={`${siteName} Logo`} width={isMobile ? 80 : 120} height={isMobile ? 80 : 120} priority />
             ) : null}
-            {siteInfo?.siteName ? (
+            {siteName ? (
               <div className="text-center leading-tight">
-                <div className="text-base font-bold text-slate-800">{siteInfo.siteName.split(' ')[0]}</div>
-                <div className="text-xs text-slate-600">{siteInfo.siteName.split(' ').slice(1).join(' ')}</div>
+                <div className="text-base font-bold text-slate-800">{siteName.split(' ')[0]}</div>
+                <div className="text-xs text-slate-600">{siteName.split(' ').slice(1).join(' ')}</div>
               </div>
             ) : null}
           </Link>

--- a/src/contexts/SiteInfoContext.tsx
+++ b/src/contexts/SiteInfoContext.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { createContext, useContext, ReactNode } from 'react';
+
+interface SiteInfo {
+  siteName: string;
+  logoUrl: string;
+  description?: string;
+}
+
+const SiteInfoContext = createContext<SiteInfo | undefined>(undefined);
+
+export function SiteInfoProvider({ siteInfo, children }: { siteInfo: SiteInfo; children: ReactNode }) {
+  return <SiteInfoContext.Provider value={siteInfo}>{children}</SiteInfoContext.Provider>;
+}
+
+export function useSiteInfo() {
+  const context = useContext(SiteInfoContext);
+  if (!context) {
+    throw new Error('useSiteInfo must be used within a SiteInfoProvider');
+  }
+  return context;
+}
+
+export type { SiteInfo };


### PR DESCRIPTION
## Summary
- add SiteInfoContext to share logo and site name across client components
- fetch site info server-side in RootLayout and wrap with SiteInfoProvider
- consume shared site info in AppHeader and Sidebar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b10d9bd48331959181ad29954c9d