### PR TITLE
feat: export all products as Markdown or JSON

### DIFF
--- a/src/app/(shop)/admin/products/page.tsx
+++ b/src/app/(shop)/admin/products/page.tsx
@@ -925,38 +925,24 @@ const AdminProductsPage = () => {
       const response = await fetch(`/api/products/generate-all-content?format=${format}`, {
         credentials: 'include'
       });
-      
+
       if (!response.ok) {
         const error = await response.json();
         toast.error(error.error || 'เกิดข้อผิดพลาดในการสร้างข้อความสินค้าทั้งหมด');
         return;
       }
 
-      if (format === 'markdown') {
-        // ดาวน์โหลดไฟล์ Markdown
-        const blob = await response.blob();
-        const url = window.URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `all-products-content.md`;
-        document.body.appendChild(a);
-        a.click();
-        window.URL.revokeObjectURL(url);
-        document.body.removeChild(a);
-        toast.success('ดาวน์โหลดไฟล์ Markdown ทั้งหมดสำเร็จ');
-      } else if (format === 'json') {
-        // ดาวน์โหลดไฟล์ JSON
-        const blob = await response.blob();
-        const url = window.URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `all-products-content.json`;
-        document.body.appendChild(a);
-        a.click();
-        window.URL.revokeObjectURL(url);
-        document.body.removeChild(a);
-        toast.success('ดาวน์โหลดไฟล์ JSON ทั้งหมดสำเร็จ');
-      }
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      const fileName = `all-products-content.${format === 'markdown' ? 'md' : 'json'}`;
+      a.download = fileName;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+      toast.success(`ดาวน์โหลดไฟล์ ${format === 'markdown' ? 'Markdown' : 'JSON'} ทั้งหมดสำเร็จ`);
     } catch (error) {
       console.error('Error generating all products content:', error);
       toast.error('เกิดข้อผิดพลาดในการสร้างข้อความสินค้าทั้งหมด');


### PR DESCRIPTION
## Summary
- add "Markdown ทั้งหมด" and "JSON ทั้งหมด" export buttons to products admin header
- generate files `all-products-content.md` or `.json` with success toasts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c1f1410c8331a450c08bb5d3adf3