### PR TITLE
Handle zero shipping fee in product content

### DIFF
--- a/src/app/api/products/[id]/generate-content/route.ts
+++ b/src/app/api/products/[id]/generate-content/route.ts
@@ -87,7 +87,7 @@ function generateMarkdownContent(product: any) {
     units.forEach((unit: any, index: number) => {
       markdown += `${index + 1}. **${unit.label}**\n`;
       markdown += `   - ราคา: ฿${unit.price.toLocaleString()}\n`;
-      if (unit.shippingFee) {
+      if (unit.shippingFee !== undefined) {
         markdown += `   - ค่าส่ง: ฿${unit.shippingFee.toLocaleString()}\n`;
       }
       if (unit.multiplier && unit.multiplier > 1) {


### PR DESCRIPTION
## Summary
- Ensure shipping fees of 0 are still rendered when generating product content

## Testing
- `node <<'NODE'
const unit={label:'A',price:100,shippingFee:0};
let markdown='';
if(unit.shippingFee !== undefined){
  markdown += `   - ค่าส่ง: ฿${unit.shippingFee.toLocaleString()}\n`;
}
console.log(markdown);
NODE`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: found errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ceb86bf08331971eabd870edc52a