### PR TITLE
Fetch full product details for bulk content export

### DIFF
--- a/src/app/(shop)/admin/products/page.tsx
+++ b/src/app/(shop)/admin/products/page.tsx
@@ -922,7 +922,7 @@ const AdminProductsPage = () => {
 
   const generateAllProductsContent = async (format: 'markdown' | 'json') => {
     try {
-      const response = await fetch(`/api/products/generate-all-content?format=${format}&detail=summary`, {
+      const response = await fetch(`/api/products/generate-all-content?format=${format}&detail=full`, {
         credentials: 'include'
       });
 


### PR DESCRIPTION
## Summary
- Ensure admin bulk content downloads request full product details

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: @typescript-eslint/no-unused-vars and other lint errors)
- `curl -I 'http://localhost:3000/api/products/generate-all-content?format=markdown&detail=full'` (fails: HTTP/1.1 401 Unauthorized)


------
https://chatgpt.com/codex/tasks/task_e_68a4ceb042e48331a1f02dd0b561eae2