### PR TITLE
feat: include shipping fee in product content

### DIFF
--- a/src/app/api/products/[id]/generate-content/route.ts
+++ b/src/app/api/products/[id]/generate-content/route.ts
@@ -64,7 +64,7 @@ function generateProductContent(product: any) {
 
 // สร้าง Markdown content
 function generateMarkdownContent(product: any) {
-  const { name, description, price, units, options, skuConfig, skuVariants, category, isAvailable } = product;
+  const { name, description, price, units, options, skuConfig, skuVariants, category, isAvailable, shippingFee } = product;
   
   let markdown = `# ${name}\n\n`;
   
@@ -78,7 +78,11 @@ function generateMarkdownContent(product: any) {
   // ราคา
   if (price !== undefined) {
     markdown += `## ราคา\n`;
-    markdown += `- **ราคาเริ่มต้น**: ฿${price.toLocaleString()}\n\n`;
+    markdown += `- **ราคาเริ่มต้น**: ฿${price.toLocaleString()}\n`;
+    if (typeof shippingFee === 'number') {
+      markdown += `- **ค่าส่งเริ่มต้น**: ฿${shippingFee.toLocaleString()}\n`;
+    }
+    markdown += `\n`;
   }
   
   // หน่วยสินค้า
@@ -186,7 +190,7 @@ function generateMarkdownContent(product: any) {
 
 // สร้าง JSON content
 function generateJSONContent(product: any) {
-  const { name, description, price, units, options, skuConfig, skuVariants, category, isAvailable } = product;
+  const { name, description, price, units, options, skuConfig, skuVariants, category, isAvailable, shippingFee } = product;
   
   const jsonContent = {
     product: {
@@ -196,6 +200,7 @@ function generateJSONContent(product: any) {
       category: category || 'ทั่วไป',
       isAvailable: isAvailable !== false,
       price: price !== undefined ? price : null,
+      shippingFee: shippingFee !== undefined ? shippingFee : null,
       units: units || [],
       options: options || [],
       createdAt: product.createdAt,
@@ -239,3 +244,5 @@ function generateJSONContent(product: any) {
   
   return jsonContent;
 }
+
+export { generateMarkdownContent, generateJSONContent };

--- a/src/app/api/products/generate-all-content/route.ts
+++ b/src/app/api/products/generate-all-content/route.ts
@@ -98,13 +98,14 @@ function generateAllProductsMarkdown(products: any[], detail: 'full' | 'summary'
 
     if (detail === 'summary') {
       // ตารางสรุปสินค้าแบบย่อ
-      markdown += `| ชื่อสินค้า | สถานะ | ราคาเริ่มต้น | SKU Variants |\n`;
-      markdown += `|---|---|---|---|\n`;
+      markdown += `| ชื่อสินค้า | สถานะ | ราคาเริ่มต้น | ค่าส่งเริ่มต้น | SKU Variants |\n`;
+      markdown += `|---|---|---|---|---|\n`;
       categoryProducts.forEach((product: any) => {
         const status = product.isAvailable !== false ? '✅ พร้อมขาย' : '❌ สินค้าหมด';
         const price = product.price !== undefined ? `฿${product.price.toLocaleString()}` : '-';
+        const shippingFee = product.shippingFee !== undefined ? `฿${product.shippingFee.toLocaleString()}` : '-';
         const skuCount = product.skuVariants && product.skuVariants.length > 0 ? product.skuVariants.length : '-';
-        markdown += `| ${product.name} | ${status} | ${price} | ${skuCount} |\n`;
+        markdown += `| ${product.name} | ${status} | ${price} | ${shippingFee} | ${skuCount} |\n`;
       });
       markdown += `\n`;
 
@@ -127,6 +128,9 @@ function generateAllProductsMarkdown(products: any[], detail: 'full' | 'summary'
 
         if (product.price !== undefined) {
           markdown += `- **ราคาเริ่มต้น**: ฿${product.price.toLocaleString()}\n`;
+        }
+        if (typeof product.shippingFee === 'number') {
+          markdown += `- **ค่าส่งเริ่มต้น**: ฿${product.shippingFee.toLocaleString()}\n`;
         }
 
         if (product.units && product.units.length > 0) {
@@ -194,6 +198,7 @@ function generateAllProductsJSON(products: any[]) {
       category: product.category || 'ทั่วไป',
       isAvailable: product.isAvailable !== false,
       price: product.price !== undefined ? product.price : null,
+      shippingFee: product.shippingFee !== undefined ? product.shippingFee : null,
       units: product.units || [],
       options: product.options || [],
       skuConfig: product.skuConfig || null,
@@ -232,6 +237,8 @@ function generateAllProductsJSON(products: any[]) {
   
   return jsonContent;
 }
+
+export { generateAllProductsMarkdown, generateAllProductsJSON };
 
 // ฟังก์ชันคำนวณสถิติ SKU
 function getSkuStatistics(products: any[]) {


### PR DESCRIPTION
## Summary
- include shipping fee details in single-product content generation
- expose shipping fee for batch product content generation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: many eslint errors across the repo)*
- `node /tmp/test-shipping.js`
- `node /tmp/test-all.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4cebca6148331aa39fa897670f9c6