### PR TITLE
feat: include shipping fee in product content generation

### DIFF
--- a/src/app/api/products/[id]/generate-content/route.ts
+++ b/src/app/api/products/[id]/generate-content/route.ts
@@ -51,7 +51,7 @@ export async function GET(request: NextRequest, context: unknown) {
 
 // ฟังก์ชันสร้างข้อความสินค้า
 function generateProductContent(product: any) {
-  const { name, description, price, units, options, skuConfig, skuVariants, category, isAvailable } = product;
+  const { name, description, price, units, options, skuConfig, skuVariants, category, isAvailable, shippingFee } = product;
 
   // สร้าง Markdown content
   const markdown = generateMarkdownContent(product);
@@ -64,7 +64,7 @@ function generateProductContent(product: any) {
 
 // สร้าง Markdown content
 function generateMarkdownContent(product: any) {
-  const { name, description, price, units, options, skuConfig, skuVariants, category, isAvailable } = product;
+  const { name, description, price, units, options, skuConfig, skuVariants, category, isAvailable, shippingFee } = product;
   
   let markdown = `# ${name}\n\n`;
   
@@ -75,10 +75,16 @@ function generateMarkdownContent(product: any) {
   markdown += `- **สถานะ**: ${isAvailable !== false ? 'พร้อมขาย' : 'สินค้าหมด'}\n`;
   markdown += `- **รายละเอียด**: ${description}\n\n`;
   
-  // ราคา
-  if (price !== undefined) {
+  // ราคาและค่าส่ง
+  if (price !== undefined || shippingFee !== undefined) {
     markdown += `## ราคา\n`;
-    markdown += `- **ราคาเริ่มต้น**: ฿${price.toLocaleString()}\n\n`;
+    if (price !== undefined) {
+      markdown += `- **ราคาเริ่มต้น**: ฿${price.toLocaleString()}\n`;
+    }
+    if (shippingFee !== undefined) {
+      markdown += `- **ค่าส่ง**: ฿${shippingFee.toLocaleString()}\n`;
+    }
+    markdown += `\n`;
   }
   
   // หน่วยสินค้า
@@ -186,7 +192,7 @@ function generateMarkdownContent(product: any) {
 
 // สร้าง JSON content
 function generateJSONContent(product: any) {
-  const { name, description, price, units, options, skuConfig, skuVariants, category, isAvailable } = product;
+  const { name, description, price, units, options, skuConfig, skuVariants, category, isAvailable, shippingFee } = product;
   
   const jsonContent = {
     product: {
@@ -196,6 +202,7 @@ function generateJSONContent(product: any) {
       category: category || 'ทั่วไป',
       isAvailable: isAvailable !== false,
       price: price !== undefined ? price : null,
+      shippingFee: shippingFee !== undefined ? shippingFee : null,
       units: units || [],
       options: options || [],
       createdAt: product.createdAt,

--- a/src/app/api/products/generate-all-content/route.ts
+++ b/src/app/api/products/generate-all-content/route.ts
@@ -98,13 +98,14 @@ function generateAllProductsMarkdown(products: any[], detail: 'full' | 'summary'
 
     if (detail === 'summary') {
       // ตารางสรุปสินค้าแบบย่อ
-      markdown += `| ชื่อสินค้า | สถานะ | ราคาเริ่มต้น | SKU Variants |\n`;
-      markdown += `|---|---|---|---|\n`;
+      markdown += `| ชื่อสินค้า | สถานะ | ราคาเริ่มต้น | ค่าส่ง | SKU Variants |\n`;
+      markdown += `|---|---|---|---|---|\n`;
       categoryProducts.forEach((product: any) => {
         const status = product.isAvailable !== false ? '✅ พร้อมขาย' : '❌ สินค้าหมด';
         const price = product.price !== undefined ? `฿${product.price.toLocaleString()}` : '-';
+        const shippingFee = product.shippingFee !== undefined ? `฿${product.shippingFee.toLocaleString()}` : '-';
         const skuCount = product.skuVariants && product.skuVariants.length > 0 ? product.skuVariants.length : '-';
-        markdown += `| ${product.name} | ${status} | ${price} | ${skuCount} |\n`;
+        markdown += `| ${product.name} | ${status} | ${price} | ${shippingFee} | ${skuCount} |\n`;
       });
       markdown += `\n`;
 
@@ -127,6 +128,9 @@ function generateAllProductsMarkdown(products: any[], detail: 'full' | 'summary'
 
         if (product.price !== undefined) {
           markdown += `- **ราคาเริ่มต้น**: ฿${product.price.toLocaleString()}\n`;
+        }
+        if (product.shippingFee !== undefined) {
+          markdown += `- **ค่าส่ง**: ฿${product.shippingFee.toLocaleString()}\n`;
         }
 
         if (product.units && product.units.length > 0) {
@@ -194,6 +198,7 @@ function generateAllProductsJSON(products: any[]) {
       category: product.category || 'ทั่วไป',
       isAvailable: product.isAvailable !== false,
       price: product.price !== undefined ? product.price : null,
+      shippingFee: product.shippingFee !== undefined ? product.shippingFee : null,
       units: product.units || [],
       options: product.options || [],
       skuConfig: product.skuConfig || null,


### PR DESCRIPTION
## Summary
- include shipping fee in individual product content generation
- expose shipping fee in bulk product content outputs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Multiple ESLint errors)*
- `node - <<'NODE' ...` *(verifies shippingFee appears in outputs)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d05fb5c08331a0ac6169f4fe0aee