### PR TITLE
Expose shipping fee in generated product content

### DIFF
--- a/src/app/api/products/[id]/generate-content/route.ts
+++ b/src/app/api/products/[id]/generate-content/route.ts
@@ -157,6 +157,9 @@ function generateMarkdownContent(product: any) {
   markdown += `- Name: ${name}\n`;
   markdown += `- Category: ${category || 'ทั่วไป'}\n`;
   markdown += `- Description: ${description}\n`;
+  if (typeof shippingFee === 'number') {
+    markdown += `- Shipping Fee: ฿${shippingFee.toLocaleString()}\n`;
+  }
   
   if (skuConfig) {
     markdown += `- SKU Prefix: ${skuConfig.prefix}\n`;
@@ -201,7 +204,10 @@ function generateJSONContent(product: any) {
       isAvailable: isAvailable !== false,
       price: price !== undefined ? price : null,
       shippingFee: shippingFee !== undefined ? shippingFee : null,
-      units: units || [],
+      units: (units || []).map((u: any) => ({
+        ...u,
+        shippingFee: u.shippingFee !== undefined ? u.shippingFee : null,
+      })),
       options: options || [],
       createdAt: product.createdAt,
       updatedAt: product.updatedAt

--- a/src/app/api/products/generate-all-content/route.ts
+++ b/src/app/api/products/generate-all-content/route.ts
@@ -190,7 +190,9 @@ export function generateAllProductsMarkdown(products: any[], detail: 'full' | 's
   markdown += `## 🤖 คำแนะนำ \n`;
   markdown += `\`\`\`\n`;
   markdown += `- **การอัปเดต**: ข้อมูลนี้จะอัปเดต realtime ตามข้อมูลในฐานข้อมูลใน https://www.winrichdynamic.com/\n`;
-  
+  markdown += `- **ข้อมูลค่าส่ง**: แสดงค่าส่งเริ่มต้นของแต่ละสินค้า (ถ้ามี)\n`;
+  markdown += `\`\`\`\n`;
+
   return markdown;
 }
 
@@ -220,7 +222,10 @@ function generateAllProductsJSON(products: any[]) {
       isAvailable: product.isAvailable !== false,
       price: product.price !== undefined ? product.price : null,
       shippingFee: product.shippingFee !== undefined ? product.shippingFee : null,
-      units: product.units || [],
+      units: (product.units || []).map((u: any) => ({
+        ...u,
+        shippingFee: u.shippingFee !== undefined ? u.shippingFee : null,
+      })),
       options: product.options || [],
       skuConfig: product.skuConfig || null,
       skuVariants: product.skuVariants || [],


### PR DESCRIPTION
## Summary
- show shipping fees in single-product content markdown and JSON
- propagate shipping fees through bulk product content generation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*
- `node product_test.log script` (custom test verifying shippingFee in outputs)


------
https://chatgpt.com/codex/tasks/task_e_68a4d23d37ac8331b80a04af3ba16809