### PR TITLE
feat: add test instruction builder

### DIFF
--- a/src/app/(shop)/admin/test-menu/page.tsx
+++ b/src/app/(shop)/admin/test-menu/page.tsx
@@ -7,6 +7,7 @@ import { PERMISSIONS } from '@/constants/permissions';
 export default function TestMenuPage() {
   const { hasPermission, isAdmin, loading: permissionsLoading } = usePermissions();
   const [debugInfo, setDebugInfo] = useState<any>({});
+  const [instructions, setInstructions] = useState<string>('');
 
   useEffect(() => {
     // ทดสอบการทำงานของ permissions
@@ -105,7 +106,29 @@ export default function TestMenuPage() {
           >
             Test Permissions in Console
           </button>
+          <button
+            onClick={async () => {
+              try {
+                const res = await fetch('/api/test-build-instructions?refresh=true');
+                const data = await res.json();
+                setInstructions(data.instructions || '');
+              } catch (err) {
+                console.error('Error building instructions:', err);
+              }
+            }}
+            className="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600"
+          >
+            Build Instructions from Google
+          </button>
         </div>
+        {instructions && (
+          <div className="mt-4">
+            <h3 className="font-semibold mb-2">Generated Instructions</h3>
+            <pre className="bg-gray-100 p-4 rounded text-sm overflow-auto whitespace-pre-wrap">
+              {instructions}
+            </pre>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/app/api/test-build-instructions/route.ts
+++ b/src/app/api/test-build-instructions/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildSystemInstructions, refreshGoogleDataCache } from '@/utils/openai-utils';
+
+export async function GET(request: NextRequest) {
+  try {
+    const refresh = request.nextUrl.searchParams.get('refresh') === 'true';
+    if (refresh) {
+      await refreshGoogleDataCache();
+    }
+    const instructions = await buildSystemInstructions('Basic');
+    return NextResponse.json({ success: true, instructions });
+  } catch (error: any) {
+    console.error('[test-build-instructions] error:', error);
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add API route to build system instructions using live Google data
- add admin test page button to generate and display instructions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4d2f842088331a6104aeade3fa0fa