### PR TITLE
refactor: remove react-json-view

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.5.2",
-    "react-json-view": "^1.21.3",
     "react-leaflet": "^5.0.0",
     "react-markdown": "^9.0.0",
     "react-places-autocomplete": "^7.3.0",

--- a/src/app/(shop)/admin/products/page.tsx
+++ b/src/app/(shop)/admin/products/page.tsx
@@ -9,7 +9,6 @@ import { PermissionGate } from '@/components/PermissionGate';
 import { usePermissions } from '@/hooks/usePermissions';
 import { PERMISSIONS } from '@/constants/permissions';
 import ReactMarkdown from 'react-markdown';
-import ReactJson from 'react-json-view';
 
 interface ProductWithId extends IProduct {
   _id: string;
@@ -2054,7 +2053,9 @@ const AdminProductsPage = () => {
               ) : previewTab === 'markdown' ? (
                 <ReactMarkdown>{previewMarkdown}</ReactMarkdown>
               ) : (
-                <ReactJson src={previewJson} name={false} collapsed={false} enableClipboard={false} />
+                <pre className="text-sm whitespace-pre-wrap break-words">
+                  {JSON.stringify(previewJson, null, 2)}
+                </pre>
               )}
             </div>
             <div className="flex justify-end space-x-2 p-4 border-t">


### PR DESCRIPTION
## Summary
- replace `react-json-view` dependency with simple `<pre>` rendering for JSON preview
- remove `react-json-view` from dependencies to avoid React peer conflicts

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d33e5eb483319fcf91fd9f52b9ff