### PR TITLE
fix: encode quotation PDF filename

### DIFF
--- a/winrichdynamic-service/src/app/api/quotations/[id]/pdf/route.ts
+++ b/winrichdynamic-service/src/app/api/quotations/[id]/pdf/route.ts
@@ -27,11 +27,16 @@ export async function GET(
     // สร้าง PDF ด้วย Puppeteer
     const pdfBuffer = await generatePDFFromHTML(html);
     
+    // เตรียมชื่อไฟล์และทำให้ปลอดภัยสำหรับ HTTP headers
+    const fileName = `ใบเสนอราคา_${(quotation as any).quotationNumber || 'unknown'}.pdf`;
+    const asciiFileName = `quotation_${(quotation as any).quotationNumber || 'unknown'}.pdf`;
+    const encodedFileName = encodeURIComponent(fileName);
+
     // ส่งกลับเป็น PDF
     return new NextResponse(pdfBuffer as any, {
       headers: {
         'Content-Type': 'application/pdf',
-        'Content-Disposition': `attachment; filename="ใบเสนอราคา_${(quotation as any).quotationNumber || 'unknown'}.pdf"`
+        'Content-Disposition': `attachment; filename="${asciiFileName}"; filename*=UTF-8''${encodedFileName}`
       }
     });
     


### PR DESCRIPTION
## Summary
- sanitize non-ASCII filename in quotation PDF response

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot read config file: /workspace/pu-star-site/node_modules/eslint-config-next/index.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9bf43908833198f99af26edbda94